### PR TITLE
add separate type of password for each user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.idea
+Makefile
+autom4te.cache
+config.h
+config.log
+config.status
+*.o
+*.so

--- a/README
+++ b/README
@@ -12,6 +12,8 @@ module.
 
 Compilation & Installation
 ==========================
+first install required packages:
+    $ sudo apt install libpam0g-dev
 
 pam_sqlite3 is autoconf'ed, thus, compiling should be a matter of:
 

--- a/pam_mod_misc.h
+++ b/pam_mod_misc.h
@@ -45,6 +45,7 @@
 #define PAM_OPT_ECHO_PASS		0x20
 
 __BEGIN_DECLS
+int pam_conversation(pam_handle_t *pamh, const char *prompt, int options, char **res);
 int  pam_get_pass(pam_handle_t *, const char **, const char *, int);
 int  pam_get_confirm_pass(pam_handle_t *, const char **, const char *,
         const char *, int);


### PR DESCRIPTION
Separate type of password for each user will add by this MR. For this a passwd_type column added to db with integer type and can have 1-5 for value (1: plane, 2: MD5, 3: SHA256, 4: SHA512, 5: ENCRYPTED). If the user doesn't specified any type the default_passwd_type value in the config file will used for password type.

**this is the database scheme:**

![Screenshot_20221119_120416](https://user-images.githubusercontent.com/40910599/202842400-b33c2474-0aef-4f21-bd88-d5c02b170dde.png)

**this is config file for pam_sqlite3.conf:**
```
database = /tmp/routing/user.db
table = users
user_column = username
pwd_column = password
pwd_type_column = password_type
expired_column = expired
newtok_column = pwreq
debug
```

**what happen in authentication:**
when `pam_sm_authenticate` called by PAM, password and password_type will get from database. based on password_type value, the stored password in db will compared with hashed or plain entered password.

**what happen in change password:**
when `pam_sm_chauthtok` called by PAM after user authentication with previous routine the new password and new password_type will get from user interactively and the password hashed based on pass_type and both password and password type will update.

Also following changes happen:
1) .git ignore updated
2) README updated for install required package